### PR TITLE
Use explicit encoding when opening training file

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -37,7 +37,7 @@ def get_dataset(path, tokenizer, max_size=1000000000):
         }
         return sample
 
-    data = json.load(open(path))[:max_size]
+    data = json.load(open(path, "r", encoding="utf-8"))[:max_size]
     data = [{**d, "idx": idx} for idx, d in enumerate(data)]
 
     keys = data[0].keys()


### PR DESCRIPTION
When running on Google Colab, we encounter the following error:
```
[rank0]: json.decoder.JSONDecodeError: Unterminated string starting at: line 1 column 40894398 (char 40894397)
[rank0]:[W206 00:01:56.957532686 ProcessGroupNCCL.cpp:1250] Warning: WARNING: process group has NOT been destroyed before we destruct ProcessGroupNCCL. On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL operations have finished in this process. In rare cases this process can exit before this point and block the progress of another member of the process group. This constraint has always been present,  but this warning has only been added since PyTorch 2.4 (function operator())
```

Opening the file with explicit encoding resolves this.