### PR TITLE
Fixed ReadMe prosqa->prontoqa

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Then run the following to train the model:
 torchrun --nnodes 1 --nproc_per_node 4 run.py args/prontoqa_coconut.yaml
 ```
 
-Find the checkpoint with best validation accuracy, and put the path as `load_model_path` in [args/prosqa_coconut_eval.yaml](args/prosqa_coconut_eval.yaml). To evaluate:
+Find the checkpoint with best validation accuracy, and put the path as `load_model_path` in [args/prontoqa_coconut_eval.yaml](args/prontoqa_coconut_eval.yaml). To evaluate:
 
 ```bash
-torchrun --nnodes 1 --nproc_per_node 4 run.py args/prosqa_coconut_eval.yaml
+torchrun --nnodes 1 --nproc_per_node 4 run.py args/prontoqa_coconut_eval.yaml
 ```
 
 


### PR DESCRIPTION
In Readme->Reproducing Experiments->ProntoQA, the instructions for evaluating ProntoQA training results seem to confuse ProsQA and ProntoQA. This has been corrected here.